### PR TITLE
Add Activity argument to onActivityResult

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,6 +20,6 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.20.+'
+    compile 'com.facebook.react:react-native:+'
     compile 'com.google.android.gms:play-services-location:8.4.0'
 }

--- a/android/src/main/java/com/reactlibrary/RNGooglePlacePickerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNGooglePlacePickerModule.java
@@ -50,7 +50,6 @@ public class RNGooglePlacePickerModule extends ReactContextBaseJavaModule implem
             callback.invoke(response);
             return;
         }
-
         try {
             PlacePicker.IntentBuilder intentBuilder = new PlacePicker.IntentBuilder();
             Intent intent = intentBuilder.build(currentActivity);
@@ -72,8 +71,8 @@ public class RNGooglePlacePickerModule extends ReactContextBaseJavaModule implem
         }
     }
 
-    @Override
-    public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
+    // removed @Override temporarily just to get it working on different versions of RN
+    public void onActivityResult(final Activity activity, final int requestCode, final int resultCode, final Intent data) {
         if (mCallback == null || requestCode != REQUEST_PLACE_PICKER) {
             return;
         }
@@ -92,5 +91,19 @@ public class RNGooglePlacePickerModule extends ReactContextBaseJavaModule implem
             return;
         }
     }
+
+    // removed @Override temporarily just to get it working on different versions of RN
+    // Ignored, required to implement ActivityEventListener for RN < 0.33
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+      this.onActivityResult(null, requestCode, resultCode, data);
+    }
+
+    /**
+   * Called when a new intent is passed to the activity
+   */
+   @Override
+   public void onNewIntent(Intent intent){
+     // ToDo
+   }
 
 }

--- a/android/src/main/java/com/reactlibrary/RNGooglePlacePickerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNGooglePlacePickerModule.java
@@ -81,9 +81,13 @@ public class RNGooglePlacePickerModule extends ReactContextBaseJavaModule implem
             final Place place = PlacePicker.getPlace(data, reactContext);
             final CharSequence address = place.getAddress();
             final LatLng coordinate = place.getLatLng();
+			final CharSequence name = place.getName();
+			final CharSequence id = place.getId();
             response.putString("address", address.toString());
             response.putDouble("latitude", coordinate.latitude);
             response.putDouble("longitude", coordinate.longitude);
+			response.putString("name", name.toString());
+			response.putString("google_id", id.toString());
             mCallback.invoke(response);
         } else {
             response.putBoolean("didCancel", true);


### PR DESCRIPTION
This changed in react-native v0.33.0-rc.0
See [facebook/react-native@fbd2e13](https://github.com/facebook/react-native/commit/fbd2e139103e3d520f6dfc009d6200f8b8168e35)

Updated the Override Method onActivityResult to format:
- public void onActivityResult(**final Activity activity**, final int requestCode, final int resultCode, final Intent data)

