### PR TITLE
add google_id and name in response for iOS

### DIFF
--- a/ios/RNGooglePlacePicker.m
+++ b/ios/RNGooglePlacePicker.m
@@ -26,6 +26,16 @@ RCT_EXPORT_METHOD(show:
             } else {
                 [response setObject:[NSNull null] forKey:@"address"];
             }
+			if (place.name) {
+				[response setObject:place.name forKey:@"name"];
+			} else {
+				[response setObject:[NSNull null] forKey:@"name"];
+			}
+			if (place.placeID) {
+				[response setObject:place.placeID forKey:@"google_id"];
+			} else {
+				[response setObject:[NSNull null] forKey:@"google_id"];
+			}
             [response setObject:@(place.coordinate.latitude) forKey:@"latitude"];
             [response setObject:@(place.coordinate.longitude) forKey:@"longitude"];
             callback(@[response]);


### PR DESCRIPTION
This code was not tested.

However, the code was based in https://developers.google.com/places/ios-api/placepicker