### PR TITLE
Support more recent versions of google play services. Places library …

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,5 +21,6 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-location:8.4.0'
+    compile 'com.google.android.gms:play-services-places:+'
+
 }


### PR DESCRIPTION
…has moved from com.google.android.gms:play-services-location to com.google.android.gms:play-services-places since 9.0.2.

From @geordasche, #10 