### PR TITLE
Compatibility for RN version < 0.40

### DIFF
--- a/ios/RNGooglePlacePicker.h
+++ b/ios/RNGooglePlacePicker.h
@@ -1,4 +1,8 @@
+#if __has_include(<React/RCTBridgeModule.h>)
+#import <React/RCTBridgeModule.h>
+#else // Compatibility for RN version < 0.40
 #import "RCTBridgeModule.h"
+#endif
 
 @interface RNGooglePlacePicker : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
fixes `Duplicate RCTMethodInfo` error
reference : https://github.com/yonahforst/react-native-permissions/issues/137